### PR TITLE
Highlight comment blocks (/* ... */)

### DIFF
--- a/syntax/monkey-c.vim
+++ b/syntax/monkey-c.vim
@@ -37,6 +37,7 @@ syntax match	monkeyCNumber		"\<\d\+[eE][-+]\=\d\+[fFdD]\=\>"
 syntax match	monkeyCNumber		"\<\d\+\([eE][-+]\=\d\+\)\=[fFdD]\>"
 syntax match	monkeyCLabel		":\w\+"
 syntax match	monkeyCComment		"\v//.*$"
+syntax region	monkeyCCommentBlock	start="/\*" end="*/"
 
 highlight link	monkeyCString		String
 highlight link	monkeyCCharacter	Character
@@ -54,6 +55,6 @@ highlight link	monkeyCOperator		Operator
 highlight link	monkeyCNumber		Number
 highlight link	monkeyCLabel		Label
 highlight link	monkeyCComment		Comment
+highlight link	monkeyCCommentBlock	Comment
 
 let b:current_syntax = "monkey-c"
-


### PR DESCRIPTION
Works with single line or multi line comment blocks that look like this:

```
/**
 * This is my
 * comment
 */
```